### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0 - Unreleased
+## 2.0.0 - 29.08.2021
 
 ### Added
 - Assign reviewers using labels


### PR DESCRIPTION
## 2.0.0 - 29.08.2021

### Added
- Assign reviewers using labels

### Changed
- [breaking change] `ignore_files` renamed to `ignore`